### PR TITLE
Add MinGW building

### DIFF
--- a/.github/workflows/windows-mingw.yml
+++ b/.github/workflows/windows-mingw.yml
@@ -1,0 +1,124 @@
+name: Windows MinGW
+on: 
+  push:
+    paths-ignore:
+      - 'README.md'
+      - 'LICENSE'
+  pull_request:
+    paths-ignore:
+      - 'README.md'
+      - 'LICENSE'
+jobs:
+  build:
+    name: Build
+    runs-on: windows-2019
+    strategy:
+      matrix:
+        include:
+          - qt_arch: win32_mingw53
+            qt_ver: 5.9.9
+            qt_tools: "tools_mingw,5.3.0-2,qt.tools.win32_mingw530"
+            qt_tools_mingw_install: mingw530_32
+          - qt_arch: win32_mingw53
+            qt_ver: 5.10.1
+            qt_tools: "tools_mingw,5.3.0-2,qt.tools.win32_mingw530"
+            qt_tools_mingw_install: mingw530_32
+          - qt_arch: win32_mingw53
+            qt_ver: 5.11.3
+            qt_tools: "tools_mingw,5.3.0-2,qt.tools.win32_mingw530"
+            qt_tools_mingw_install: mingw530_32
+          - qt_arch: win32_mingw73
+            qt_ver: 5.12.10
+            qt_tools: "tools_mingw,7.3.0-1-202004170606,qt.tools.win32_mingw730"
+            qt_tools_mingw_install: mingw730_32
+          - qt_arch: win32_mingw73
+            qt_ver: 5.13.2
+            qt_tools: "tools_mingw,7.3.0-1-202004170606,qt.tools.win32_mingw730"
+            qt_tools_mingw_install: mingw730_32
+          - qt_arch: win32_mingw73
+            qt_ver: 5.14.2
+            qt_tools: "tools_mingw,7.3.0-1-202004170606,qt.tools.win32_mingw730"
+            qt_tools_mingw_install: mingw730_32
+          - qt_arch: win64_mingw73
+            qt_ver: 5.12.10
+            qt_tools: "tools_mingw,7.3.0-1-202004170606,qt.tools.win64_mingw730"
+            qt_tools_mingw_install: mingw730_64
+          - qt_arch: win64_mingw73
+            qt_ver: 5.13.2
+            qt_tools: "tools_mingw,7.3.0-1-202004170606,qt.tools.win64_mingw730"
+            qt_tools_mingw_install: mingw730_64
+          - qt_arch: win64_mingw73
+            qt_ver: 5.14.2
+            qt_tools: "tools_mingw,7.3.0-1-202004170606,qt.tools.win64_mingw730"
+            qt_tools_mingw_install: mingw730_64
+          - qt_arch: win32_mingw81
+            qt_ver: 5.15.2
+            qt_tools: "tools_mingw,8.1.0-1-202004170606,qt.tools.win32_mingw810"
+            qt_tools_mingw_install: mingw810_32
+          - qt_arch: win64_mingw81
+            qt_ver: 5.15.2
+            qt_tools: "tools_mingw,8.1.0-1-202004170606,qt.tools.win64_mingw810"
+            qt_tools_mingw_install: mingw810_64
+          - qt_arch: win64_mingw81
+            qt_ver: 6.0.0
+            qt_tools: "tools_mingw,8.1.0-1-202004170606,qt.tools.win64_mingw810"
+            qt_tools_mingw_install: mingw810_64
+    env:
+      targetName: HelloActions-Qt.exe
+    steps:
+      - name: Install Qt
+        uses: jurplel/install-qt-action@v2.10.0
+        with:
+          version: ${{ matrix.qt_ver }}
+          arch: ${{ matrix.qt_arch }}
+          tools: ${{ matrix.qt_tools }}
+          aqtversion: '==0.10.0'
+          cached: 'false'
+      - uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
+      - name: Qt 5 environment configuration
+        if: ${{ startsWith( matrix.qt_ver, 5 ) }}
+        shell: pwsh
+        run: |
+          Write-Output "${{ env.Qt5_DIR }}/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          Write-Output "${{ env.Qt5_DIR }}/../../Tools/${{ matrix.qt_tools_mingw_install }}/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      - name: Qt 6 environment configuration
+        if: ${{ startsWith( matrix.qt_ver, 6 ) }}
+        shell: pwsh
+        run: |
+          Write-Output "${{ env.Qt6_DIR }}/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          Write-Output "${{ env.Qt6_DIR }}/../../Tools/${{ matrix.qt_tools_mingw_install }}/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+      - name: where is qmake & where is mingw32-make
+        shell: pwsh
+        run: |
+          Get-Command -Name 'qmake' | Format-List
+          Get-Command -Name 'mingw32-make' | Format-List
+      - name: mingw-build
+        id: build
+        shell: cmd
+        run: |
+          qmake
+          mingw32-make
+      - name: package
+        id: package      
+        env:
+          archiveName: ${{ matrix.qt_ver }}-${{ matrix.qt_target }}-${{ matrix.qt_arch }}
+        shell: pwsh
+        run: |
+          & scripts\windows-mingw-publish.ps1 ${env:archiveName} ${env:targetName}
+           $name = ${env:archiveName}
+           echo "::set-output name=packageName::$name"       
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ${{ steps.package.outputs.packageName }}
+          path: ${{ steps.package.outputs.packageName }}.zip
+      - name: uploadRelease
+        if: startsWith(github.event.ref, 'refs/tags/')
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ${{ steps.package.outputs.packageName }}.zip
+          asset_name: ${{ steps.package.outputs.packageName }}.zip
+          tag: ${{ github.ref }}
+          overwrite: true 

--- a/scripts/windows-mingw-publish.ps1
+++ b/scripts/windows-mingw-publish.ps1
@@ -1,0 +1,36 @@
+[CmdletBinding()]
+param (
+    [string] $archiveName, [string] $targetName
+)
+# 外部环境变量包括:
+# archiveName: ${{ matrix.qt_ver }}-${{ matrix.qt_arch }}
+
+
+# archiveName: 5.15.2-win64_mingw81
+
+$scriptDir = $PSScriptRoot
+$currentDir = Get-Location
+Write-Host "currentDir" $currentDir
+Write-Host "scriptDir" $scriptDir
+
+function Main() {
+
+    New-Item -ItemType Directory $archiveName
+    # 拷贝exe
+    Copy-Item bin\release\$targetName $archiveName\
+    # 拷贝依赖
+    windeployqt --qmldir . --plugindir $archiveName\plugins --no-translations --compiler-runtime $archiveName\$targetName
+    # 删除不必要的文件
+    $excludeList = @("*.qmlc", "*.ilk", "*.exp", "*.lib", "*.pdb")
+    Remove-Item -Path $archiveName -Include $excludeList -Recurse -Force
+    # 打包zip
+    Compress-Archive -Path $archiveName $archiveName'.zip'
+}
+
+if ($null -eq $archiveName || $null -eq $targetName) {
+    Write-Host "args missing, archiveName is" $archiveName ", targetName is" $targetName
+    return
+}
+Main
+
+


### PR DESCRIPTION
你好，我添加了 MinGW 的配置。

值得注意的是， mingw53 的三个 Qt 版本 5.9.9 、 5.10.1 和 5.11.3 能够正常构建，但打包后的程序在 Windows 7 和 10 上执行时不会显示窗口，也没有错误提示。这与该仓库中现有的 5.9.9-msvc2015 和 5.9.9-msvc2017_64 有相同的表现。我暂时还不知道是哪里的问题。
