### PR TITLE
Add Qt 6.0.0 for MSVC 2019 64-bit

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -49,6 +49,11 @@ jobs:
             qt_arch: win64_msvc2019_64
             msvc_arch: x64
             qt_arch_install: msvc2019_64          
+          # 6.0.0 参考 https://mirrors.cloud.tencent.com/qt/online/qtsdkrepository/windows_x86/desktop/qt6_600/
+          - qt_ver: 6.0.0
+            qt_arch: win64_msvc2019_64
+            msvc_arch: x64
+            qt_arch_install: msvc2019_64
     env:
       targetName: HelloActions-Qt.exe
     # 步骤


### PR DESCRIPTION
你好，这是用于 MSVC 2019 64-bit 的 Qt 6.0.0 的配置。
