### PR TITLE
Use actions/checkout@v2 to prevent errors

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -29,7 +29,7 @@ jobs:
           target: ${{ matrix.qt_target }}
           # Architecture for Windows/Android
           arch: ${{ matrix.qt_arch }}  
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
         with:
           fetch-depth: 1
       - name: build android

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -25,7 +25,7 @@ jobs:
           version: ${{ matrix.qt_ver }}
           # Target platform for build
           target: ${{ matrix.qt_target }}
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
         with:
           fetch-depth: 1
       - name: build ios

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           version: ${{ matrix.qt_ver }}
           cached: 'false'
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
         with:
           fetch-depth: 1
       - name: build macos

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -27,7 +27,7 @@ jobs:
           cached: 'false'
       - name: ubuntu install GL library
         run: sudo apt-get install -y libglew-dev libglfw3-dev
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
         with:
           fetch-depth: 1
       - name: build ubuntu

--- a/.github/workflows/windows-mingw.yml
+++ b/.github/workflows/windows-mingw.yml
@@ -75,7 +75,7 @@ jobs:
           tools: ${{ matrix.qt_tools }}
           aqtversion: '==0.10.0'
           cached: 'false'
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
         with:
           fetch-depth: 1
       - name: Qt 5 environment configuration

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -73,7 +73,7 @@ jobs:
           aqtversion: '==0.10.0'
           cached: 'false'
       # 拉取代码
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
         with:
           fetch-depth: 1
       # msvc编译

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ dll，以此来保证在大部分Windows环境都能正常运行。
 
 2. 获取项目代码
 
-这一步用Actions官方核心模板：actions/checkout@v1
+这一步用Actions官方核心模板：actions/checkout@v2
 
 3. 执行qmake、make
 


### PR DESCRIPTION
https://github.com/jaredtao/HelloActions-Qt/runs/1940483926?check_suite_focus=true

```
git checkout --progress --force ef8f82f78ada861d183d395a9b7efa4e58c893b6
Error: fatal: reference is not a tree: ef8f82f78ada861d183d395a9b7efa4e58c893b6
Warning: Git checkout failed on shallow repository, this might because of git fetch with depth '1' doesn't include the checkout commit 'ef8f82f78ada861d183d395a9b7efa4e58c893b6'.
Error: Git checkout failed with exit code: 128
Error: Exit code 1 returned from process: file name '/home/runner/runners/2.277.1/bin/Runner.PluginHost', arguments 'action "GitHub.Runner.Plugins.Repository.v1_0.CheckoutTask, Runner.Plugins"'.
```

See commit message for more details.