### PR TITLE
Ubuntu.yml: upgrade "install-qt-action"

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -37,12 +37,12 @@ jobs:
       - name: package
         run: |
           # 拷贝依赖
-          macdeployqt bin/release/${targetName}.app -qmldir=. -verbose=1 -dmg
+          macdeployqt bin/release/${env:targetName}.app -qmldir=. -verbose=1 -dmg
       # 上传artifacts          
       - uses: actions/upload-artifact@v2
         with:
           name: ${targetName}_${{matrix.qt_ver}}.zip
-          path: bin/release/${targetName}.app
+          path: bin/release/${env:targetName}.app
       # tag 上传Release
       - name: uploadRelease
         if: startsWith(github.event.ref, 'refs/tags/')

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -21,7 +21,7 @@ jobs:
         qt_arch: [gcc_64]
     steps:
       - name: Install Qt
-        uses: jurplel/install-qt-action@v2.10.0
+        uses: jurplel/install-qt-action@v2.13.0
         with:
           version: ${{ matrix.qt_ver }}
           cached: 'false'


### PR DESCRIPTION
"jurplel/install-qt-action" needs to be upgraded to latest 2.13.0, current is 2.10.0.
Otherwise, when doing the action it would throw an error and fail to build.

```bash
python3 -m aqt install 5.12.10 linux desktop -O /home/runner/work/project-name/Qt
Traceback (most recent call last):
  File "/home/runner/.local/lib/python3.6/site-packages/importlib_metadata/__init__.py", line 170, in __getitem__
    return next(iter(self.select(name=name)))
StopIteration

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3.6/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib/python3.6/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/home/runner/.local/lib/python3.6/site-packages/aqt/__main__.py", line 28, in <module>
    sys.exit(main())
  File "/home/runner/.local/lib/python3.6/site-packages/aqt/__init__.py", line 38, in main
    return cli.run()
  File "/home/runner/.local/lib/python3.6/site-packages/aqt/cli.py", line 352, in run
    return args.func(args)
  File "/home/runner/.local/lib/python3.6/site-packages/aqt/cli.py", line 142, in run_install
    self._run_common_part(output_dir, mirror)
  File "/home/runner/.local/lib/python3.6/site-packages/aqt/cli.py", line 123, in _run_common_part
    self.show_aqt_version()
  File "/home/runner/.local/lib/python3.6/site-packages/aqt/cli.py", line 245, in show_aqt_version
    module_name = dist.entry_points[0].name
  File "/home/runner/.local/lib/python3.6/site-packages/importlib_metadata/__init__.py", line 172, in __getitem__
    raise KeyError(name)
KeyError: 0
Error: The process 'python3' failed with exit code 1
```